### PR TITLE
CMakeLists.txt: Add 'INSTALL_DO_NOT_BUNDLE' to avoid the conflict of Spack and Bundling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ set_target_properties (SINGULAR-parallel-installation
   PROPERTIES
   INSTALL_RPATH_USE_LINK_PATH TRUE
 )
-bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DO_NOT_BUNDLE INSTALL_DIRECTORY "lib")
+bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DIRECTORY "lib" INSTALL_DO_NOT_BUNDLE)
 
 extended_add_library (NAME module
   TYPE SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ install (DIRECTORY "${SINGULAR_HOME}/"
   USE_SOURCE_PERMISSIONS
 )
 
-set (INSTALL_DO_NOT_BUNDLE ON CACHE BOOL "Do not bundle installed targets")
 
 set(SP_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}")
 set(PFD_SING_LIB_PATH "${CMAKE_INSTALL_PREFIX}/LIB")
@@ -69,6 +68,7 @@ extended_add_library (NAME installation
 set_target_properties (SINGULAR-parallel-installation
   PROPERTIES
   INSTALL_RPATH_USE_LINK_PATH TRUE
+  INSTALL_DO_NOT_BUNDLE ON 
 )
 bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DIRECTORY "lib")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,11 +64,11 @@ extended_add_library (NAME installation
   POSITION_INDEPENDENT
   INSTALL
 )
-option (INSTALL_DO_NOT_BUNDLE ON)
 
 set_target_properties (SINGULAR-parallel-installation
   PROPERTIES
-  INSTALL_RPATH_USE_LINK_PATH TRUE 
+  INSTALL_RPATH_USE_LINK_PATH TRUE
+  INSTALL_DO_NOT_BUNDLE TRUE
 )
 bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DIRECTORY "lib")
 
@@ -92,6 +92,7 @@ set_target_properties (SINGULAR-parallel-module
   PROPERTIES
   INSTALL_RPATH "$ORIGIN/../lib"
   INSTALL_RPATH_USE_LINK_PATH TRUE
+  INSTALL_DO_NOT_BUNDLE TRUE
 )
 bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-module INSTALL_DIRECTORY "LIB")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ find_boost (1.61 REQUIRED QUIET FROM_GPISPACE_INSTALLATION COMPONENTS
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/modules")
 find_package (Singular REQUIRED)
 
+option (INSTALL_DO_NOT_BUNDLE ON)
+
 set (BUNDLE_ROOT "libexec/bundle")
 bundle_GPISpace (DESTINATION "${BUNDLE_ROOT}/gpispace"
   COMPONENTS "runtime"
@@ -54,7 +56,6 @@ include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 include_directories ("${CMAKE_CURRENT_BINARY_DIR}/src")
 include_directories ("${CMAKE_BINARY_DIR}")
 
-option (INSTALL_DO_NOT_BUNDLE ON)
 extended_add_library (NAME installation
   TYPE SHARED
   NAMESPACE SINGULAR-parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,12 @@ bundle_GPISpace (DESTINATION "${BUNDLE_ROOT}/gpispace"
              "monitoring"
 )
 
-set (INSTALL_DO_NOT_BUNDLE ON CACHE BOOL "Do not bundle installed targets")
-
 install (DIRECTORY "${SINGULAR_HOME}/"
   DESTINATION libexec/bundle/singular
   USE_SOURCE_PERMISSIONS
 )
+
+set (INSTALL_DO_NOT_BUNDLE ON CACHE BOOL "Do not bundle installed targets")
 
 set(SP_INSTALL_PATH "${CMAKE_INSTALL_PREFIX}")
 set(PFD_SING_LIB_PATH "${CMAKE_INSTALL_PREFIX}/LIB")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ set_target_properties (SINGULAR-parallel-installation
   PROPERTIES
   INSTALL_RPATH_USE_LINK_PATH TRUE
 )
-bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DIRECTORY INSTALL_DO_NOT_BUNDLE "lib")
+bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DO_NOT_BUNDLE INSTALL_DIRECTORY "lib")
 
 extended_add_library (NAME module
   TYPE SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,8 @@ extended_add_library (NAME installation
 set_target_properties (SINGULAR-parallel-installation
   PROPERTIES
   INSTALL_RPATH_USE_LINK_PATH TRUE
-  INSTALL_DO_NOT_BUNDLE TRUE
 )
-bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DIRECTORY "lib")
+bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DIRECTORY INSTALL_DO_NOT_BUNDLE "lib")
 
 extended_add_library (NAME module
   TYPE SHARED
@@ -92,7 +91,6 @@ set_target_properties (SINGULAR-parallel-module
   PROPERTIES
   INSTALL_RPATH "$ORIGIN/../lib"
   INSTALL_RPATH_USE_LINK_PATH TRUE
-  INSTALL_DO_NOT_BUNDLE TRUE
 )
 bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-module INSTALL_DIRECTORY "LIB")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ extended_add_library (NAME installation
             Util::Generic-Headers
             GPISpace::execution
   POSITION_INDEPENDENT
-  NSTALL_DO_NOT_BUNDLE
+  INSTALL_DO_NOT_BUNDLE
   INSTALL
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set (BUNDLE_ROOT "libexec/bundle")
 bundle_GPISpace (DESTINATION "${BUNDLE_ROOT}/gpispace"
   COMPONENTS "runtime"
              "monitoring"
+  INSTALL_DO_NOT_BUNDLE
 )
 
 install (DIRECTORY "${SINGULAR_HOME}/"
@@ -62,7 +63,6 @@ extended_add_library (NAME installation
             Util::Generic-Headers
             GPISpace::execution
   POSITION_INDEPENDENT
-  INSTALL_DO_NOT_BUNDLE
   INSTALL
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ include_directories ("${CMAKE_CURRENT_SOURCE_DIR}")
 include_directories ("${CMAKE_CURRENT_BINARY_DIR}/src")
 include_directories ("${CMAKE_BINARY_DIR}")
 
-
+option (INSTALL_DO_NOT_BUNDLE ON)
 extended_add_library (NAME installation
   TYPE SHARED
   NAMESPACE SINGULAR-parallel
@@ -67,8 +67,7 @@ extended_add_library (NAME installation
 )
 set_target_properties (SINGULAR-parallel-installation
   PROPERTIES
-  INSTALL_RPATH_USE_LINK_PATH TRUE
-  INSTALL_DO_NOT_BUNDLE ON 
+  INSTALL_RPATH_USE_LINK_PATH TRUE 
 )
 bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DIRECTORY "lib")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package (GPISpace REQUIRED)
 find_package (util-cmake REQUIRED)
 include (util-cmake/add_macros)
 include (util-cmake/beautify_find_boost)
-set (INSTALL_DO_NOT_BUNDLE ON)
+set (INSTALL_DO_NOT_BUNDLE ON CACHE BOOL "")
 
 find_boost (1.61 REQUIRED QUIET FROM_GPISPACE_INSTALLATION COMPONENTS
   date_time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_boost (1.61 REQUIRED QUIET FROM_GPISPACE_INSTALLATION COMPONENTS
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/modules")
 find_package (Singular REQUIRED)
 
-set (INSTALL_DO_NOT_BUNDLE OFF CACHE BOOL "Do not bundle installed targets")
+set (INSTALL_DO_NOT_BUNDLE ON CACHE BOOL "Do not bundle installed targets")
 
 set (BUNDLE_ROOT "libexec/bundle")
 bundle_GPISpace (DESTINATION "${BUNDLE_ROOT}/gpispace"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ find_boost (1.61 REQUIRED QUIET FROM_GPISPACE_INSTALLATION COMPONENTS
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/modules")
 find_package (Singular REQUIRED)
 
+set (INSTALL_DO_NOT_BUNDLE OFF CACHE BOOL "Do not bundle installed targets")
+
 set (BUNDLE_ROOT "libexec/bundle")
 bundle_GPISpace (DESTINATION "${BUNDLE_ROOT}/gpispace"
   COMPONENTS "runtime"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ enable_testing()
 
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (INSTALL_DO_NOT_BUNDLE ON)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
@@ -37,7 +38,6 @@ set (BUNDLE_ROOT "libexec/bundle")
 bundle_GPISpace (DESTINATION "${BUNDLE_ROOT}/gpispace"
   COMPONENTS "runtime"
              "monitoring"
-  INSTALL_DO_NOT_BUNDLE
 )
 
 install (DIRECTORY "${SINGULAR_HOME}/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ enable_testing()
 
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
-set (INSTALL_DO_NOT_BUNDLE ON)
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
@@ -15,6 +14,7 @@ find_package (GPISpace REQUIRED)
 find_package (util-cmake REQUIRED)
 include (util-cmake/add_macros)
 include (util-cmake/beautify_find_boost)
+set (INSTALL_DO_NOT_BUNDLE ON)
 
 find_boost (1.61 REQUIRED QUIET FROM_GPISPACE_INSTALLATION COMPONENTS
   date_time

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,13 @@ find_boost (1.61 REQUIRED QUIET FROM_GPISPACE_INSTALLATION COMPONENTS
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/modules")
 find_package (Singular REQUIRED)
 
-set (INSTALL_DO_NOT_BUNDLE ON CACHE BOOL "Do not bundle installed targets")
-
 set (BUNDLE_ROOT "libexec/bundle")
 bundle_GPISpace (DESTINATION "${BUNDLE_ROOT}/gpispace"
   COMPONENTS "runtime"
              "monitoring"
 )
+
+set (INSTALL_DO_NOT_BUNDLE ON CACHE BOOL "Do not bundle installed targets")
 
 install (DIRECTORY "${SINGULAR_HOME}/"
   DESTINATION libexec/bundle/singular

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,13 +33,13 @@ find_boost (1.61 REQUIRED QUIET FROM_GPISPACE_INSTALLATION COMPONENTS
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/cmake/modules")
 find_package (Singular REQUIRED)
 
-option (INSTALL_DO_NOT_BUNDLE ON)
-
 set (BUNDLE_ROOT "libexec/bundle")
 bundle_GPISpace (DESTINATION "${BUNDLE_ROOT}/gpispace"
   COMPONENTS "runtime"
              "monitoring"
 )
+
+option (INSTALL_DO_NOT_BUNDLE ON)
 
 install (DIRECTORY "${SINGULAR_HOME}/"
   DESTINATION libexec/bundle/singular

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ extended_add_library (NAME installation
             Util::Generic-Headers
             GPISpace::execution
   POSITION_INDEPENDENT
+  NSTALL_DO_NOT_BUNDLE
   INSTALL
 )
 
@@ -69,7 +70,7 @@ set_target_properties (SINGULAR-parallel-installation
   PROPERTIES
   INSTALL_RPATH_USE_LINK_PATH TRUE
 )
-bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DIRECTORY "lib" INSTALL_DO_NOT_BUNDLE)
+bundle_GPISpace_add_rpath (TARGET SINGULAR-parallel-installation INSTALL_DIRECTORY "lib")
 
 extended_add_library (NAME module
   TYPE SHARED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,6 @@ bundle_GPISpace (DESTINATION "${BUNDLE_ROOT}/gpispace"
              "monitoring"
 )
 
-option (INSTALL_DO_NOT_BUNDLE ON)
-
 install (DIRECTORY "${SINGULAR_HOME}/"
   DESTINATION libexec/bundle/singular
   USE_SOURCE_PERMISSIONS
@@ -66,6 +64,8 @@ extended_add_library (NAME installation
   POSITION_INDEPENDENT
   INSTALL
 )
+option (INSTALL_DO_NOT_BUNDLE ON)
+
 set_target_properties (SINGULAR-parallel-installation
   PROPERTIES
   INSTALL_RPATH_USE_LINK_PATH TRUE 


### PR DESCRIPTION
In certain cases (currently unidentified), when installing pfd-parallel, Spack and Bundling will conflict and cause error. 
Error log is as below:
make[2]: *** [bundle-SINGULAR-parallel-installation] Error 1
make[2]: Leaving directory '/tmp/'username'/spack-stage/spack-stage-pfd-parallel-latest-ppdcins7joyz42d5skuxdawakf2lp5yv/spack-build-ppdcins'
CMakeFiles/Makefile2:194: recipe for target 'CMakeFiles/SINGULAR-parallel-installation-bundled-libraries.dir/all' failed
make[1]: *** [CMakeFiles/SINGULAR-parallel-installation-bundled-libraries.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....

After disabling bundling, the problem solved.